### PR TITLE
Bugfix/fee plan（月謝プランのプラン名一意性制約とバリデーション改善）

### DIFF
--- a/app/models/fee_plan.rb
+++ b/app/models/fee_plan.rb
@@ -2,7 +2,7 @@ class FeePlan < ApplicationRecord
   belongs_to :user
   has_many :attendances, dependent: :nullify
   
-  validates :name, presence: true
-  validates :amount, presence: true, numericality: { greater_than: 0 }
+  validates :name, presence: true, uniqueness: { scope: :user_id }
+  validates :amount, presence: true, numericality: { greater_than_or_equal_to: 0, allow_blank: true }
   validates :user, presence: true
 end

--- a/app/views/fee_plans/_form.html.erb
+++ b/app/views/fee_plans/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: fee_plan, local: true do |f| %>
+<%= form_with model: fee_plan, local: true, data: { turbo: false } do |f| %>
   <% if fee_plan.errors.any? %>
     <div class="alert alert-danger">
       <ul>

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,9 @@ module Monfee
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.1
 
+    # 日本語をデフォルトロケールに設定
+    config.i18n.default_locale = :ja
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,19 @@
+ja:
+  activerecord:
+    errors:
+      models:
+        fee_plan:
+          attributes:
+            name:
+              taken: "は既に存在しています。"
+              blank: "を入力してください。"
+            amount:
+              not_a_number: "は数値で入力してください。"
+              greater_than_or_equal_to: "は%{count}以上の値にしてください。"
+              blank: "を入力してください。"
+    attributes:
+      fee_plan:
+        name: "プラン名"
+        amount: "金額"
+    models:
+      fee_plan: "月謝プラン"


### PR DESCRIPTION
## 概要
月謝プランにおいて、同一ユーザー内でプラン名の重複を防ぐバリデーションを追加し、エラーメッセージの表示を改善しました。

## 変更内容

### 新機能
- **プラン名一意性制約**: 同一ユーザー内でプラン名が重複しないようにバリデーションを追加
- **日本語エラーメッセージ**: 適切な日本語でのバリデーションエラーメッセージを実装

###  バグ修正
- **Turbo対応**: フォーム送信時にエラーメッセージが表示されない問題を修正
- **バリデーションロジック改善**: 金額欄の空値と数値エラーの重複表示を解決
- **0円対応**: 金額に0を入力した場合もバリデーション通過するよう修正

### 変更されたファイル

**モデル**
- `app/models/fee_plan.rb`
  - プラン名の一意性制約追加（`uniqueness: { scope: :user_id }`）
  - 金額バリデーションを改善（`greater_than_or_equal_to: 0, allow_blank: true`）

**ビュー**
- `app/views/fee_plans/_form.html.erb`
  - Turbo無効化（`data: { turbo: false }`）によりエラーメッセージ表示を修正

**設定**
- `config/application.rb`
  - 日本語をデフォルトロケールに設定（`config.i18n.default_locale = :ja`）
- `config/locales/ja.yml`（新規作成）
  - 月謝プラン用の日本語エラーメッセージを定義

### バリデーション動作

| 入力パターン | 表示メッセージ |
|------------|-------------|
| プラン名が空 | 「プラン名 を入力してください。」 |
| プラン名が重複 | 「プラン名 は既に存在しています。」 |
| 金額が空 | 「金額 を入力してください。」 |
| 金額が文字列 | 「金額 は数値で入力してください。」 |
| 金額が負の数 | 「金額 は0以上の値にしてください。」 |
| 金額が0 |  バリデーション通過 |

#### 技術的詳細
- 同一ユーザー内でのみプラン名の一意性を保証（異なるユーザー間では同じプラン名可能）
- Rails 7のTurbo機能による非同期送信がエラー表示を阻害していた問題を解決
- ActiveRecordのバリデーションメッセージを日本語ロケールファイルで一元管理

#### テスト結果
- プラン名重複時の適切なエラー表示を確認
- 金額バリデーションの正常動作を確認
- 正常なデータでの月謝プラン作成が可能なことを確認