### PR TITLE
Bugfix/error message（バリデーションエラー表示とUXの統一改善）

### DIFF
--- a/app/controllers/attendances_controller.rb
+++ b/app/controllers/attendances_controller.rb
@@ -8,31 +8,21 @@ class AttendancesController < ApplicationController
 
   def new
     @attendance = Attendance.new
+    restore_from_session(@attendance)
   end
 
   def create
     @attendance = Attendance.new(attendance_params)
-    
-    return unless set_fee_from_plan(@attendance)
-    
-    if @attendance.save
-      redirect_to student_path(@student)
-    else
-      render :new
-    end
+    save_attendance_with_error_handling { new_student_attendance_path(@student) }
   end
 
   def edit
+    restore_from_session(@attendance)
   end
 
   def update
-    return unless set_fee_from_plan(@attendance)
-    
-    if @attendance.update(attendance_params)
-      redirect_to student_path(@student)
-    else
-      render :edit
-    end
+    @attendance.assign_attributes(attendance_params)
+    save_attendance_with_error_handling { edit_student_attendance_path(@student, @attendance) }
   end
 
   def destroy
@@ -55,11 +45,6 @@ class AttendancesController < ApplicationController
       attendance.fee = fee_plan.amount
       attendance.fee_plan = fee_plan
       # fee_plan_nameはモデルのbefore_saveコールバックで自動設定される
-      return true
-    else
-      attendance.errors.add(:fee_plan_id, 'を選択してください')
-      render action_name == 'create' ? :new : :edit
-      return false
     end
   end
   
@@ -74,5 +59,38 @@ class AttendancesController < ApplicationController
 
   def attendance_choose
     @attendance = Attendance.find(params[:id])
+  end
+
+  # セッションからエラー情報と入力値を復元
+  def restore_from_session(attendance)
+    # セッションからエラー情報を復元
+    if session[:attendance_errors].present?
+      attendance.errors.add(:base, '') # エラーオブジェクトを初期化
+      session[:attendance_errors].each do |field, messages|
+        messages.each { |message| attendance.errors.add(field.to_sym, message) }
+      end
+      session.delete(:attendance_errors)
+    end
+    
+    # セッションから入力値を復元
+    if session[:attendance_params].present?
+      attendance.assign_attributes(session[:attendance_params])
+      session.delete(:attendance_params)
+    end
+  end
+
+  # 出席記録の保存とエラーハンドリング
+  def save_attendance_with_error_handling(&redirect_path_block)
+    set_fee_from_plan(@attendance)
+    
+    if @attendance.save
+      redirect_to student_path(@student)
+    else
+      # エラー情報をセッションに保存
+      session[:attendance_errors] = @attendance.errors.messages
+      session[:attendance_params] = attendance_params.except(:student_id)
+      
+      redirect_to redirect_path_block.call
+    end
   end
 end

--- a/app/controllers/fee_plans_controller.rb
+++ b/app/controllers/fee_plans_controller.rb
@@ -8,26 +8,21 @@ class FeePlansController < ApplicationController
 
   def new
     @fee_plan = current_user.fee_plans.build
+    restore_from_session(@fee_plan)
   end
 
   def create
     @fee_plan = current_user.fee_plans.build(fee_plan_params)
-    if @fee_plan.save
-      redirect_to fee_plans_path, notice: '月謝プランが作成されました。'
-    else
-      render :new
-    end
+    save_fee_plan_with_error_handling('月謝プランが作成されました。') { new_fee_plan_path }
   end
 
   def edit
+    restore_from_session(@fee_plan)
   end
 
   def update
-    if @fee_plan.update(fee_plan_params)
-      redirect_to fee_plans_path, notice: '月謝プランが更新されました。'
-    else
-      render :edit
-    end
+    @fee_plan.assign_attributes(fee_plan_params)
+    save_fee_plan_with_error_handling('月謝プランが更新されました。') { edit_fee_plan_path(@fee_plan) }
   end
 
   def destroy
@@ -43,5 +38,36 @@ class FeePlansController < ApplicationController
 
   def fee_plan_params
     params.require(:fee_plan).permit(:name, :amount)
+  end
+
+  # セッションからエラー情報と入力値を復元
+  def restore_from_session(fee_plan)
+    # セッションからエラー情報を復元
+    if session[:fee_plan_errors].present?
+      fee_plan.errors.add(:base, '') # エラーオブジェクトを初期化
+      session[:fee_plan_errors].each do |field, messages|
+        messages.each { |message| fee_plan.errors.add(field.to_sym, message) }
+      end
+      session.delete(:fee_plan_errors)
+    end
+    
+    # セッションから入力値を復元
+    if session[:fee_plan_params].present?
+      fee_plan.assign_attributes(session[:fee_plan_params])
+      session.delete(:fee_plan_params)
+    end
+  end
+
+  # 月謝プランの保存とエラーハンドリング
+  def save_fee_plan_with_error_handling(success_message, &redirect_path_block)
+    if @fee_plan.save
+      redirect_to fee_plans_path, notice: success_message
+    else
+      # エラー情報をセッションに保存
+      session[:fee_plan_errors] = @fee_plan.errors.messages
+      session[:fee_plan_params] = fee_plan_params
+      
+      redirect_to redirect_path_block.call
+    end
   end
 end

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -10,15 +10,12 @@ class StudentsController < ApplicationController
 
   def new
     @student = Student.new
+    restore_from_session(@student)
   end
 
   def create
     @student = Student.new(student_params)
-    if @student.save
-      redirect_to root_path
-    else
-      render :new
-    end
+    save_student_with_error_handling { new_student_path }
   end
 
   def show
@@ -26,14 +23,12 @@ class StudentsController < ApplicationController
   end
 
   def edit
+    restore_from_session(@student)
   end
 
   def update
-    if @student.update(student_params)
-      redirect_to student_path(@student)
-    else
-      render :edit
-    end
+    @student.assign_attributes(student_params)
+    save_student_with_error_handling { edit_student_path(@student) }
   end
 
   def destroy
@@ -48,6 +43,37 @@ class StudentsController < ApplicationController
 
   def student_choose
     @student = Student.find(params[:id])
+  end
+
+  # セッションからエラー情報と入力値を復元
+  def restore_from_session(student)
+    # セッションからエラー情報を復元
+    if session[:student_errors].present?
+      student.errors.add(:base, '') # エラーオブジェクトを初期化
+      session[:student_errors].each do |field, messages|
+        messages.each { |message| student.errors.add(field.to_sym, message) }
+      end
+      session.delete(:student_errors)
+    end
+    
+    # セッションから入力値を復元
+    if session[:student_params].present?
+      student.assign_attributes(session[:student_params])
+      session.delete(:student_params)
+    end
+  end
+
+  # 生徒情報の保存とエラーハンドリング
+  def save_student_with_error_handling(&redirect_path_block)
+    if @student.save
+      redirect_to root_path
+    else
+      # エラー情報をセッションに保存
+      session[:student_errors] = @student.errors.messages
+      session[:student_params] = student_params.except(:user_id)
+      
+      redirect_to redirect_path_block.call
+    end
   end
 
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,65 @@
+class Users::RegistrationsController < Devise::RegistrationsController
+  # バリデーションエラー時に正しいURLを保持するために、
+  # エラー発生時はリダイレクトしてflashメッセージで情報を伝える
+  def create
+    build_resource(sign_up_params)
+
+    resource.save
+    yield resource if block_given?
+    if resource.persisted?
+      if resource.active_for_authentication?
+        set_flash_message! :notice, :signed_up
+        sign_up(resource_name, resource)
+        respond_with resource, location: after_sign_up_path_for(resource)
+      else
+        set_flash_message! :notice, :"signed_up_but_#{resource.inactive_message}"
+        expire_data_after_sign_up!
+        respond_with resource, location: after_inactive_sign_up_path_for(resource)
+      end
+    else
+      clean_up_passwords resource
+      set_minimum_password_length
+      # エラー内容をsessionに保存してからリダイレクト
+      session[:registration_field_errors] = resource.errors.messages
+      session[:registration_params] = sign_up_params.except(:password, :password_confirmation)
+      redirect_to new_user_registration_path
+    end
+  end
+
+  def new
+    build_resource
+    # 個別フィールドのエラー情報を復元（重複を避けるため、個別フィールドのみ復元）
+    if session[:registration_field_errors]
+      session[:registration_field_errors].each do |field, messages|
+        messages.each do |message|
+          resource.errors.add(field, message)
+        end
+      end
+      session.delete(:registration_field_errors)
+    end
+
+    # 全体エラーメッセージのクリーンアップ
+    if session[:registration_errors]
+      session.delete(:registration_errors)
+    end
+    
+    # 入力値を復元
+    if session[:registration_params]
+      resource.assign_attributes(session[:registration_params])
+      session.delete(:registration_params)
+    end
+    
+    yield resource if block_given?
+    respond_with resource
+  end
+
+  protected
+
+  def after_sign_up_path_for(resource)
+    root_path
+  end
+
+  def after_inactive_sign_up_path_for(resource)
+    root_path
+  end
+end

--- a/app/models/attendance.rb
+++ b/app/models/attendance.rb
@@ -3,7 +3,7 @@ class Attendance < ApplicationRecord
   belongs_to :fee_plan, optional: true
 
   validates :entry, presence: true
-  validates :fee, presence: true
+  validates :fee_plan_id, presence: true
 
   before_save :set_fee_plan_name
 

--- a/app/views/attendances/_form.html.erb
+++ b/app/views/attendances/_form.html.erb
@@ -1,4 +1,14 @@
-<%= form_with model: [student, attendance], local: true do |f|%>
+<%= form_with model: [student, attendance], local: true, data: { turbo: false } do |f|%>
+  <% if attendance.errors.any? %>
+    <div class="alert alert-danger">
+      <ul>
+        <% attendance.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+  
   <div class='field'>
     <div class='field-label'>
       <%= f.label :entry, "出席日", for: 'entry_date' %>
@@ -11,12 +21,11 @@
   <div class='field'>
     <div class='field-label'>
       <%= f.label :fee_plan_id, "月謝プラン", for: 'fee_plan_select' %>
-      <span style="color: red;">*必須</span>
     </div>
     <div class='field-input'>
       <%= f.collection_select :fee_plan_id, @fee_plans, :id, :name, 
                               { prompt: "月謝プランを選択してください" }, 
-                              { class: 'form-control', id: 'fee_plan_select', required: true } %>
+                              { class: 'form-control', id: 'fee_plan_select' } %>
     </div>
   </div>
   
@@ -44,7 +53,7 @@
   </div>
   
   <div class='actions'>
-    <%= f.submit attendance.persisted? ? "更新" : "登録", class: 'btn btn-primary', id: 'submit_btn', disabled: true %>
+    <%= f.submit attendance.persisted? ? "更新" : "登録", class: 'btn btn-primary', id: 'submit_btn' %>
     <%= link_to "戻る", get_back_path(request.referer, student), class: 'btn btn-secondary' %>
   </div>
 <% end %>
@@ -108,8 +117,8 @@ document.addEventListener('turbo:load', function() {
       dateInfo.style.display = 'none';
     }
     
-    // 送信ボタンの有効/無効
-    submitBtn.disabled = !(selectedPlanId && selectedDate);
+    // 送信ボタンは常に有効（サーバーサイドバリデーションに任せる）
+    // submitBtn.disabled = !(selectedPlanId && selectedDate);
   }
   
   // イベントリスナー

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -5,48 +5,59 @@
       <h5>新規アカウントの作成</h5>
     </div>
     <div class='account-page__inner--right user-form'>
-      <%= form_with model: @user, url: user_registration_path, local: true do |f|%>
-        <%= devise_error_messages!%>
+      <%= form_with model: @user, url: user_registration_path, local: true, data: { turbo: false }, html: { id: 'new_user' } do |f|%>
+        <% if @user.errors.any? || flash[:alert] %>
+          <div class="alert alert-danger">
+            <ul>
+              <% if flash[:alert] %>
+                <li><%= flash[:alert] %></li>
+              <% end %>
+              <% @user.errors.full_messages.each do |message| %>
+                <li><%= message %></li>
+              <% end %>
+            </ul>
+          </div>
+        <% end %>
         <div class='field'>
           <div class='field-label'>
-            <%= f.label :name%>
+            <%= f.label :name, class: (@user.errors[:name].any? ? 'field_with_errors' : '') %>
           </div>
           <div class='field-input'>
-            <%= f.text_field :name%>
+            <%= f.text_field :name, class: (@user.errors[:name].any? ? 'field_with_errors' : '') %>
           </div>
         </div>
         <div class='field'>
           <div class='field-label'>
-            <%= f.label :school_name%>
+            <%= f.label :school_name, class: (@user.errors[:school_name].any? ? 'field_with_errors' : '') %>
             <i>(教室名)</i>
           </div>
           <div class='field-input'>
-            <%= f.text_field :school_name%>
+            <%= f.text_field :school_name, class: (@user.errors[:school_name].any? ? 'field_with_errors' : '') %>
           </div>
         </div>
         <div class='field'>
           <div class='field-label'>
-            <%= f.label :email%>
+            <%= f.label :email, class: (@user.errors[:email].any? ? 'field_with_errors' : '') %>
           </div>
           <div class='field-input'>
-            <%= f.email_field :email%>
+            <%= f.email_field :email, class: (@user.errors[:email].any? ? 'field_with_errors' : '') %>
           </div>
         </div>
         <div class='field'>
           <div class='field-label'>
-            <%= f.label :password%>
+            <%= f.label :password, class: (@user.errors[:password].any? ? 'field_with_errors' : '') %>
             <i>(英数字6文字以上)</i>
           </div>
           <div class='field-input'>
-            <%= f.password_field :password, autocomplete: "off"%>
+            <%= f.password_field :password, autocomplete: "off", class: (@user.errors[:password].any? ? 'field_with_errors' : '') %>
           </div>
         </div>
         <div class='field'>
           <div class='field-label'>
-            <%= f.label :password_confirmation%>
+            <%= f.label :password_confirmation, class: (@user.errors[:password_confirmation].any? ? 'field_with_errors' : '') %>
           </div>
           <div class='field-input'>
-            <%= f.password_field :password_confirmation, autocomplete: "off"%>
+            <%= f.password_field :password_confirmation, autocomplete: "off", class: (@user.errors[:password_confirmation].any? ? 'field_with_errors' : '') %>
           </div>
         </div>
         <div class='actions'>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -6,7 +6,14 @@
       <%= render "devise/shared/links"%>
     </div>
     <div class='account-page__inner--right user-form'>
-      <%= form_with model: @user, url: user_session_path, local: true do |f|%>
+      <%= form_with model: @user, url: user_session_path, local: true, data: { turbo: false } do |f|%>
+        <% if flash[:alert] %>
+          <div class="alert alert-danger">
+            <ul>
+              <li><%= flash[:alert] %></li>
+            </ul>
+          </div>
+        <% end %>
         <div class='field'>
           <div class='field-label'>
             <%= f.label :email%>

--- a/app/views/students/_form.html.erb
+++ b/app/views/students/_form.html.erb
@@ -1,4 +1,14 @@
-<%= form_with model: student, local: true do |f|%>
+<%= form_with model: student, local: true, data: { turbo: false } do |f|%>
+  <% if student.errors.any? %>
+    <div class="alert alert-danger">
+      <ul>
+        <% student.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+  
   <div class='field'>
     <div class='field-label'>
       <%= f.label :name, "生徒名"%>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -11,9 +11,20 @@ ja:
               not_a_number: "は数値で入力してください。"
               greater_than_or_equal_to: "は%{count}以上の値にしてください。"
               blank: "を入力してください。"
+        attendance:
+          attributes:
+            entry:
+              blank: "を入力してください。"
+            fee_plan_id:
+              blank: "を選択してください。"
     attributes:
       fee_plan:
         name: "プラン名"
         amount: "金額"
+      attendance:
+        entry: "出席日"
+        fee_plan_id: "月謝プラン"
+        fee: "料金"
     models:
       fee_plan: "月謝プラン"
+      attendance: "出席記録"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,4 +1,11 @@
 ja:
+  errors:
+    format: "%{attribute}%{message}"
+    messages:
+      blank: "が入力されていません"
+      too_short: "は%{count}文字以上で入力してください"
+      too_long: "は%{count}文字以内で入力してください"
+      invalid: "は不正な値です"
   activerecord:
     errors:
       models:
@@ -17,6 +24,16 @@ ja:
               blank: "を入力してください。"
             fee_plan_id:
               blank: "を選択してください。"
+        student:
+          attributes:
+            name:
+              blank: "を入力してください。"
+            age:
+              blank: "を入力してください。"
+            guardian_name:
+              blank: "を入力してください。"
+            phone_number:
+              blank: "を入力してください。"
     attributes:
       fee_plan:
         name: "プラン名"
@@ -25,6 +42,12 @@ ja:
         entry: "出席日"
         fee_plan_id: "月謝プラン"
         fee: "料金"
+      student:
+        name: "生徒名"
+        age: "年齢"
+        guardian_name: "保護者名"
+        phone_number: "電話番号"
     models:
       fee_plan: "月謝プラン"
       attendance: "出席記録"
+      student: "生徒"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,4 +1,43 @@
 ja:
+  devise:
+    failure:
+      invalid: "メールアドレスまたはパスワードが違います。"
+      not_found_in_database: "メールアドレスまたはパスワードが違います。"
+      unauthenticated: "アカウント登録もしくはログインしてください。"
+      unconfirmed: "メールアドレスの本人確認が必要です。"
+      locked: "あなたのアカウントは凍結されています。"
+      invalid_token: "認証キーが不正です。"
+      timeout: "セッションがタイムアウトしました。もう一度ログインしてください。"
+    sessions:
+      signed_in: "ログインしました。"
+      signed_out: "ログアウトしました。"
+    registrations:
+      signed_up: "アカウント登録が完了しました。"
+      updated: "アカウント情報を変更しました。"
+      destroyed: "アカウントを削除しました。またのご利用をお待ちしております。"
+    passwords:
+      send_instructions: "パスワードの再設定について数分以内にメールでご連絡いたします。"
+      updated: "パスワードが正しく変更されました。"
+      updated_not_active: "パスワードが正しく変更されました。"
+      send_paranoid_instructions: "あなたのメールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。"
+    confirmations:
+      send_instructions: "アカウントの有効化について数分以内にメールでご連絡します。"
+      send_paranoid_instructions: "メールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。"
+      confirmed: "メールアドレスが確認できました。"
+    unlocks:
+      send_instructions: "アカウントの凍結解除について数分以内にメールでご連絡します。"
+      send_paranoid_instructions: "アカウントが見つかった場合、アカウントの凍結解除について数分以内にメールでご連絡します。"
+      unlocked: "アカウントを凍結解除しました。"
+    omniauth_callbacks:
+      success: "%{kind} アカウントによる認証に成功しました。"
+      failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
+    mailer:
+      confirmation_instructions:
+        subject: "アカウント確認手順"
+      reset_password_instructions:
+        subject: "パスワード再設定手順"
+      unlock_instructions:
+        subject: "アカウント凍結解除手順"
   errors:
     format: "%{attribute}%{message}"
     messages:
@@ -6,6 +45,10 @@ ja:
       too_short: "は%{count}文字以上で入力してください"
       too_long: "は%{count}文字以内で入力してください"
       invalid: "は不正な値です"
+      confirmation: "が一致しません"
+      taken: "はすでに存在します"
+      not_a_number: "は数値で入力してください"
+      greater_than_or_equal_to: "は%{count}以上の値にしてください"
   activerecord:
     errors:
       models:
@@ -34,6 +77,21 @@ ja:
               blank: "を入力してください。"
             phone_number:
               blank: "を入力してください。"
+        user:
+          attributes:
+            name:
+              blank: "を入力してください。"
+            school_name:
+              blank: "を入力してください。"
+            email:
+              blank: "を入力してください。"
+              invalid: "の形式が正しくありません。"
+              taken: "は既に使用されています。"
+            password:
+              blank: "を入力してください。"
+              too_short: "は%{count}文字以上で入力してください。"
+            password_confirmation:
+              confirmation: "が一致しません。"
     attributes:
       fee_plan:
         name: "プラン名"
@@ -47,7 +105,14 @@ ja:
         age: "年齢"
         guardian_name: "保護者名"
         phone_number: "電話番号"
+      user:
+        name: "名前"
+        school_name: "教室名"
+        email: "メールアドレス"
+        password: "パスワード"
+        password_confirmation: "パスワード（確認）"
     models:
       fee_plan: "月謝プラン"
       attendance: "出席記録"
       student: "生徒"
+      user: "ユーザー"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
-  devise_for :users
+  devise_for :users, controllers: {
+    registrations: 'users/registrations'
+  }
   root to: "students#index"
   
   resources :fee_plans


### PR DESCRIPTION
## プルリクエスト概要

### 概要
アプリケーション全体のバリデーションエラー表示を統一し、ユーザーエクスペリエンスを大幅に改善しました。すべてのフォームで日本語エラーメッセージの統一表示、セッション管理によるエラー時URL維持、フロントエンドバリデーションの無効化など、包括的なUX改善を実装しています。

### 主な変更内容

#### 1. 出席登録機能の改善 (`34da14f`)
- **エラーメッセージの統一表示**: フォーム上部に日本語エラーメッセージを一箇所に集約
- **URL維持機能**: エラー時も`attendances/new`のURLを維持（セッション管理で実装）
- **バリデーション最適化**: ブラウザバリデーションを無効化してサーバーサイドに統一
- **コントローラーリファクタリング**: 重複コードの削除と共通処理化

#### 2. 生徒管理機能の改善 (`ac4a46f`)
- **エラー表示機能**: 生徒フォームにバリデーションエラー表示機能を追加
- **セッション管理**: エラー情報と入力値の復元機能

#### 3. Deviseフォームの改善 (`de99db5`)
- **ユーザー登録フォーム**: エラーメッセージ表示と項目強調機能を追加
- **ログインフォーム**: エラー表示の改善
- **Deviseコントローラー**: カスタムregistrationsコントローラーを実装

#### 4. 料金プラン機能の修正 (`e25eca0`)
- **URL変更問題の修正**: エラー時のURL変更問題を解決
- **エラーハンドリング統一**: 他機能と同様のエラー処理を実装

### 技術的改善

#### バックエンド
- **AttendancesController**: 重複コードの削除、共通メソッドの実装
- **FeeePlansController**, **StudentsController**: エラーハンドリングの統一
- **RegistrationsController**: Deviseのカスタマイズ実装
- **Attendanceモデル**: バリデーションルールの最適化

#### フロントエンド
- **統一エラー表示**: 全フォームでのエラーメッセージ表示統一
- **Turboの無効化**: 適切な場所でのTurbo無効化設定
- **バリデーション調整**: サーバーサイドバリデーションへの統一

#### 国際化対応
- **日本語メッセージ**: `config/locales/ja.yml`の大幅拡充
- **属性名の日本語化**: 全モデルの属性名を日本語化
- **エラーメッセージの統一**: 一貫性のある日本語エラーメッセージ

### 📊 変更統計
- **11ファイル**変更
- **335行**追加、**62行**削除
- **4つ**の主要機能エリアにわたる改善

### 改善されたUX
1. **一貫性のあるエラー表示**: 全フォームで統一されたエラーメッセージ表示
2. **URL維持**: エラー時にユーザーが期待するURLを維持
3. **日本語対応**: 完全な日本語エラーメッセージとラベル
4. **入力値保持**: エラー時に入力値が失われない仕組み
5. **シンプルな操作**: 不要なフロントエンドバリデーションを削除

### テスト対象
- [ ] 出席登録フォームのエラー表示
- [ ] 生徒登録フォームのエラー表示  
- [ ] 料金プラン登録フォームのエラー表示
- [ ] ユーザー登録フォームのエラー表示
- [ ] エラー時のURL維持
- [ ] 入力値の復元機能